### PR TITLE
Fix undeclared var warning

### DIFF
--- a/.idea/ClojureProjectResolveSettings.xml
+++ b/.idea/ClojureProjectResolveSettings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ClojureProjectResolveSettings">
+    <currentScheme>IDE</currentScheme>
+  </component>
+</project>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <wildcardResourcePatterns>
+      <entry name="!dev-resources:*" />
+      <entry name="!resources:*" />
+      <entry name="!?*.java" />
+      <entry name="!?*.form" />
+      <entry name="!?*.class" />
+      <entry name="!?*.groovy" />
+      <entry name="!?*.scala" />
+      <entry name="!?*.flex" />
+      <entry name="!?*.kt" />
+      <entry name="!?*.clj" />
+      <entry name="!?*.aj" />
+    </wildcardResourcePatterns>
+  </component>
+</project>

--- a/.idea/libraries/Leiningen__args4j_2_33.xml
+++ b/.idea/libraries/Leiningen__args4j_2_33.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Leiningen: args4j:2.33">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.m2/repository/args4j/args4j/2.33/args4j-2.33.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Leiningen__clojure_complete_0_2_4.xml
+++ b/.idea/libraries/Leiningen__clojure_complete_0_2_4.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Leiningen: clojure-complete:0.2.4">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.m2/repository/clojure-complete/clojure-complete/0.2.4/clojure-complete-0.2.4.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Leiningen__com_google_code_findbugs_jsr305_3_0_1.xml
+++ b/.idea/libraries/Leiningen__com_google_code_findbugs_jsr305_3_0_1.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Leiningen: com.google.code.findbugs/jsr305:3.0.1">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.m2/repository/com/google/code/findbugs/jsr305/3.0.1/jsr305-3.0.1.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Leiningen__com_google_code_gson_gson_2_7.xml
+++ b/.idea/libraries/Leiningen__com_google_code_gson_gson_2_7.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Leiningen: com.google.code.gson/gson:2.7">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.m2/repository/com/google/code/gson/gson/2.7/gson-2.7.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Leiningen__com_google_errorprone_error_prone_annotations_2_0_18.xml
+++ b/.idea/libraries/Leiningen__com_google_errorprone_error_prone_annotations_2_0_18.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Leiningen: com.google.errorprone/error_prone_annotations:2.0.18">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.m2/repository/com/google/errorprone/error_prone_annotations/2.0.18/error_prone_annotations-2.0.18.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Leiningen__com_google_guava_guava_20_0.xml
+++ b/.idea/libraries/Leiningen__com_google_guava_guava_20_0.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Leiningen: com.google.guava/guava:20.0">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.m2/repository/com/google/guava/guava/20.0/guava-20.0.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Leiningen__com_google_javascript_closure_compiler_externs_v20170910.xml
+++ b/.idea/libraries/Leiningen__com_google_javascript_closure_compiler_externs_v20170910.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Leiningen: com.google.javascript/closure-compiler-externs:v20170910">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.m2/repository/com/google/javascript/closure-compiler-externs/v20170910/closure-compiler-externs-v20170910.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Leiningen__com_google_javascript_closure_compiler_unshaded_v20170910.xml
+++ b/.idea/libraries/Leiningen__com_google_javascript_closure_compiler_unshaded_v20170910.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Leiningen: com.google.javascript/closure-compiler-unshaded:v20170910">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.m2/repository/com/google/javascript/closure-compiler-unshaded/v20170910/closure-compiler-unshaded-v20170910.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Leiningen__com_google_jsinterop_jsinterop_annotations_1_0_0.xml
+++ b/.idea/libraries/Leiningen__com_google_jsinterop_jsinterop_annotations_1_0_0.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Leiningen: com.google.jsinterop/jsinterop-annotations:1.0.0">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.m2/repository/com/google/jsinterop/jsinterop-annotations/1.0.0/jsinterop-annotations-1.0.0.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Leiningen__com_google_protobuf_protobuf_java_3_0_2.xml
+++ b/.idea/libraries/Leiningen__com_google_protobuf_protobuf_java_3_0_2.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Leiningen: com.google.protobuf/protobuf-java:3.0.2">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.m2/repository/com/google/protobuf/protobuf-java/3.0.2/protobuf-java-3.0.2.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Leiningen__net_cgrand_macrovich_0_2_0.xml
+++ b/.idea/libraries/Leiningen__net_cgrand_macrovich_0_2_0.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Leiningen: net.cgrand/macrovich:0.2.0">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.m2/repository/net/cgrand/macrovich/0.2.0/macrovich-0.2.0.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Leiningen__org_clojure_clojure_1_9_0.xml
+++ b/.idea/libraries/Leiningen__org_clojure_clojure_1_9_0.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Leiningen: org.clojure/clojure:1.9.0">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.m2/repository/org/clojure/clojure/1.9.0/clojure-1.9.0.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Leiningen__org_clojure_clojurescript_1_9_946.xml
+++ b/.idea/libraries/Leiningen__org_clojure_clojurescript_1_9_946.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Leiningen: org.clojure/clojurescript:1.9.946">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.m2/repository/org/clojure/clojurescript/1.9.946/clojurescript-1.9.946.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Leiningen__org_clojure_core_specs_alpha_0_1_24.xml
+++ b/.idea/libraries/Leiningen__org_clojure_core_specs_alpha_0_1_24.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Leiningen: org.clojure/core.specs.alpha:0.1.24">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.m2/repository/org/clojure/core.specs.alpha/0.1.24/core.specs.alpha-0.1.24.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Leiningen__org_clojure_data_json_0_2_6.xml
+++ b/.idea/libraries/Leiningen__org_clojure_data_json_0_2_6.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Leiningen: org.clojure/data.json:0.2.6">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.m2/repository/org/clojure/data.json/0.2.6/data.json-0.2.6.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Leiningen__org_clojure_google_closure_library_0_0_20170809_b9c14c6b.xml
+++ b/.idea/libraries/Leiningen__org_clojure_google_closure_library_0_0_20170809_b9c14c6b.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Leiningen: org.clojure/google-closure-library:0.0-20170809-b9c14c6b">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.m2/repository/org/clojure/google-closure-library/0.0-20170809-b9c14c6b/google-closure-library-0.0-20170809-b9c14c6b.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Leiningen__org_clojure_google_closure_library_third_party_0_0_20170809_b9c14c6b.xml
+++ b/.idea/libraries/Leiningen__org_clojure_google_closure_library_third_party_0_0_20170809_b9c14c6b.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Leiningen: org.clojure/google-closure-library-third-party:0.0-20170809-b9c14c6b">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.m2/repository/org/clojure/google-closure-library-third-party/0.0-20170809-b9c14c6b/google-closure-library-third-party-0.0-20170809-b9c14c6b.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Leiningen__org_clojure_spec_alpha_0_1_143.xml
+++ b/.idea/libraries/Leiningen__org_clojure_spec_alpha_0_1_143.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Leiningen: org.clojure/spec.alpha:0.1.143">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.m2/repository/org/clojure/spec.alpha/0.1.143/spec.alpha-0.1.143.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Leiningen__org_clojure_tools_logging_0_3_1.xml
+++ b/.idea/libraries/Leiningen__org_clojure_tools_logging_0_3_1.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Leiningen: org.clojure/tools.logging:0.3.1">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.m2/repository/org/clojure/tools.logging/0.3.1/tools.logging-0.3.1.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Leiningen__org_clojure_tools_nrepl_0_2_12.xml
+++ b/.idea/libraries/Leiningen__org_clojure_tools_nrepl_0_2_12.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Leiningen: org.clojure/tools.nrepl:0.2.12">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.m2/repository/org/clojure/tools.nrepl/0.2.12/tools.nrepl-0.2.12.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Leiningen__org_clojure_tools_reader_1_1_0.xml
+++ b/.idea/libraries/Leiningen__org_clojure_tools_reader_1_1_0.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Leiningen: org.clojure/tools.reader:1.1.0">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.m2/repository/org/clojure/tools.reader/1.1.0/tools.reader-1.1.0.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Leiningen__org_mozilla_rhino_1_7R5.xml
+++ b/.idea/libraries/Leiningen__org_mozilla_rhino_1_7R5.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Leiningen: org.mozilla/rhino:1.7R5">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.m2/repository/org/mozilla/rhino/1.7R5/rhino-1.7R5.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Leiningen__re_frame_0_10_4.xml
+++ b/.idea/libraries/Leiningen__re_frame_0_10_4.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Leiningen: re-frame:0.10.4">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.m2/repository/re-frame/re-frame/0.10.4/re-frame-0.10.4.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Leiningen__reagent_0_7_0.xml
+++ b/.idea/libraries/Leiningen__reagent_0_7_0.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Leiningen: reagent:0.7.0">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.m2/repository/reagent/reagent/0.7.0/reagent-0.7.0.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/markdown-navigator.xml
+++ b/.idea/markdown-navigator.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MarkdownProjectSettings" wasCopied="true">
+    <PreviewSettings splitEditorLayout="SPLIT" splitEditorPreview="PREVIEW" useGrayscaleRendering="false" zoomFactor="1.0" maxImageWidth="0" showGitHubPageIfSynced="false" allowBrowsingInPreview="false" synchronizePreviewPosition="true" highlightPreviewType="NONE" highlightFadeOut="5" highlightOnTyping="true" synchronizeSourcePosition="true" verticallyAlignSourceAndPreviewSyncPosition="true" showSearchHighlightsInPreview="false" showSelectionInPreview="true" openRemoteLinks="true" replaceUnicodeEmoji="false" lastLayoutSetsDefault="false">
+      <PanelProvider>
+        <provider providerId="com.vladsch.idea.multimarkdown.editor.swing.html.panel" providerName="Default - Swing" />
+      </PanelProvider>
+    </PreviewSettings>
+    <ParserSettings gitHubSyntaxChange="false" emojiShortcuts="1" emojiImages="0">
+      <PegdownExtensions>
+        <option name="ABBREVIATIONS" value="false" />
+        <option name="ANCHORLINKS" value="true" />
+        <option name="ASIDE" value="false" />
+        <option name="ATXHEADERSPACE" value="true" />
+        <option name="AUTOLINKS" value="true" />
+        <option name="DEFINITIONS" value="false" />
+        <option name="DEFINITION_BREAK_DOUBLE_BLANK_LINE" value="false" />
+        <option name="FENCED_CODE_BLOCKS" value="true" />
+        <option name="FOOTNOTES" value="false" />
+        <option name="HARDWRAPS" value="false" />
+        <option name="HTML_DEEP_PARSER" value="false" />
+        <option name="INSERTED" value="false" />
+        <option name="QUOTES" value="false" />
+        <option name="RELAXEDHRULES" value="true" />
+        <option name="SMARTS" value="false" />
+        <option name="STRIKETHROUGH" value="true" />
+        <option name="SUBSCRIPT" value="false" />
+        <option name="SUPERSCRIPT" value="false" />
+        <option name="SUPPRESS_HTML_BLOCKS" value="false" />
+        <option name="SUPPRESS_INLINE_HTML" value="false" />
+        <option name="TABLES" value="true" />
+        <option name="TASKLISTITEMS" value="true" />
+        <option name="TOC" value="false" />
+        <option name="WIKILINKS" value="true" />
+      </PegdownExtensions>
+      <ParserOptions>
+        <option name="ADMONITION_EXT" value="false" />
+        <option name="ATTRIBUTES_EXT" value="false" />
+        <option name="COMMONMARK_LISTS" value="true" />
+        <option name="DUMMY" value="false" />
+        <option name="EMOJI_SHORTCUTS" value="true" />
+        <option name="ENUMERATED_REFERENCES_EXT" value="false" />
+        <option name="FLEXMARK_FRONT_MATTER" value="false" />
+        <option name="GFM_LOOSE_BLANK_LINE_AFTER_ITEM_PARA" value="false" />
+        <option name="GFM_TABLE_RENDERING" value="true" />
+        <option name="GITBOOK_URL_ENCODING" value="false" />
+        <option name="GITHUB_LISTS" value="false" />
+        <option name="GITHUB_WIKI_LINKS" value="true" />
+        <option name="HEADER_ID_NO_DUPED_DASHES" value="false" />
+        <option name="JEKYLL_FRONT_MATTER" value="false" />
+        <option name="NO_TEXT_ATTRIBUTES" value="false" />
+        <option name="PARSE_HTML_ANCHOR_ID" value="false" />
+        <option name="SIM_TOC_BLANK_LINE_SPACER" value="true" />
+      </ParserOptions>
+    </ParserSettings>
+    <HtmlSettings headerTopEnabled="false" headerBottomEnabled="false" bodyTopEnabled="false" bodyBottomEnabled="false" embedUrlContent="false" addPageHeader="true" embedImages="false" embedHttpImages="false" imageUriSerials="false">
+      <GeneratorProvider>
+        <provider providerId="com.vladsch.idea.multimarkdown.editor.swing.html.generator" providerName="Default Swing HTML Generator" />
+      </GeneratorProvider>
+      <headerTop />
+      <headerBottom />
+      <bodyTop />
+      <bodyBottom />
+    </HtmlSettings>
+    <CssSettings previewScheme="UI_SCHEME" cssUri="" isCssUriEnabled="false" isCssUriSerial="false" isCssTextEnabled="false" isDynamicPageWidth="true">
+      <StylesheetProvider>
+        <provider providerId="com.vladsch.idea.multimarkdown.editor.swing.html.css" providerName="Default Swing Stylesheet" />
+      </StylesheetProvider>
+      <ScriptProviders />
+      <cssText />
+      <cssUriHistory />
+    </CssSettings>
+    <HtmlExportSettings updateOnSave="false" parentDir="" targetDir="" cssDir="" scriptDir="" plainHtml="false" imageDir="" copyLinkedImages="false" imageUniquifyType="0" targetExt="" useTargetExt="false" noCssNoScripts="false" linkToExportedHtml="true" exportOnSettingsChange="true" regenerateOnProjectOpen="false" linkFormatType="HTTP_ABSOLUTE" />
+    <LinkMapSettings>
+      <textMaps />
+    </LinkMapSettings>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="LeiningenProjectsManager">
+    <option name="projectFiles">
+      <list>
+        <option value="file://$PROJECT_DIR$/project.clj" />
+      </list>
+    </option>
+  </component>
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/classes" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -7,7 +7,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager">
+  <component name="ProjectRootManager" version="2" project-jdk-name="IDE SDK" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/classes" />
   </component>
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/cljs-react-navigation.iml" filepath="$PROJECT_DIR$/cljs-react-navigation.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/cljs-react-navigation.iml
+++ b/cljs-react-navigation.iml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module cursive.leiningen.project.LeiningenProjectsManager.displayName="cljs-react-navigation:0.1.5-SNAPSHOT" cursive.leiningen.project.LeiningenProjectsManager.isLeinModule="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <output url="file://$MODULE_DIR$/target/classes" />
+    <output-test url="file://$MODULE_DIR$/target/classes" />
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/dev-resources" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/resources" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Leiningen: args4j:2.33" level="project" />
+    <orderEntry type="library" name="Leiningen: clojure-complete:0.2.4" level="project" />
+    <orderEntry type="library" name="Leiningen: com.google.code.findbugs/jsr305:3.0.1" level="project" />
+    <orderEntry type="library" name="Leiningen: com.google.code.gson/gson:2.7" level="project" />
+    <orderEntry type="library" name="Leiningen: com.google.errorprone/error_prone_annotations:2.0.18" level="project" />
+    <orderEntry type="library" name="Leiningen: com.google.guava/guava:20.0" level="project" />
+    <orderEntry type="library" name="Leiningen: com.google.javascript/closure-compiler-externs:v20170910" level="project" />
+    <orderEntry type="library" name="Leiningen: com.google.javascript/closure-compiler-unshaded:v20170910" level="project" />
+    <orderEntry type="library" name="Leiningen: com.google.jsinterop/jsinterop-annotations:1.0.0" level="project" />
+    <orderEntry type="library" name="Leiningen: com.google.protobuf/protobuf-java:3.0.2" level="project" />
+    <orderEntry type="library" name="Leiningen: net.cgrand/macrovich:0.2.0" level="project" />
+    <orderEntry type="library" name="Leiningen: org.clojure/clojure:1.9.0" level="project" />
+    <orderEntry type="library" name="Leiningen: org.clojure/clojurescript:1.9.946" level="project" />
+    <orderEntry type="library" name="Leiningen: org.clojure/core.specs.alpha:0.1.24" level="project" />
+    <orderEntry type="library" name="Leiningen: org.clojure/data.json:0.2.6" level="project" />
+    <orderEntry type="library" name="Leiningen: org.clojure/google-closure-library-third-party:0.0-20170809-b9c14c6b" level="project" />
+    <orderEntry type="library" name="Leiningen: org.clojure/google-closure-library:0.0-20170809-b9c14c6b" level="project" />
+    <orderEntry type="library" name="Leiningen: org.clojure/spec.alpha:0.1.143" level="project" />
+    <orderEntry type="library" name="Leiningen: org.clojure/tools.logging:0.3.1" level="project" />
+    <orderEntry type="library" name="Leiningen: org.clojure/tools.nrepl:0.2.12" level="project" />
+    <orderEntry type="library" name="Leiningen: org.clojure/tools.reader:1.1.0" level="project" />
+    <orderEntry type="library" name="Leiningen: org.mozilla/rhino:1.7R5" level="project" />
+    <orderEntry type="library" name="Leiningen: re-frame:0.10.4" level="project" />
+    <orderEntry type="library" name="Leiningen: reagent:0.7.0" level="project" />
+  </component>
+</module>

--- a/cljs-react-navigation.iml
+++ b/cljs-react-navigation.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module cursive.leiningen.project.LeiningenProjectsManager.displayName="cljs-react-navigation:0.1.5-SNAPSHOT" cursive.leiningen.project.LeiningenProjectsManager.isLeinModule="true" type="JAVA_MODULE" version="4">
+<module cursive.leiningen.project.LeiningenProjectsManager.displayName="cljs-react-navigation:0.1.5-SNAPSHOT_1" cursive.leiningen.project.LeiningenProjectsManager.isLeinModule="true" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/classes" />

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cljs-react-navigation "0.1.4-SNAPSHOT"
+(defproject cljs-react-navigation "0.1.5-SNAPSHOT"
   :description "CLJS Wrappers for react-navigation"
   :url "https://github.com/seantempesta/cljs-react-navigation"
   :license {:name "MIT"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cljs-react-navigation "0.1.5-SNAPSHOT_1"
+(defproject cljs-react-navigation "0.2.0-alpha1"
   :description "CLJS Wrappers for react-navigation"
   :url "https://github.com/seantempesta/cljs-react-navigation"
   :license {:name "MIT"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cljs-react-navigation "0.1.3"
+(defproject cljs-react-navigation "0.1.4-SNAPSHOT"
   :description "CLJS Wrappers for react-navigation"
   :url "https://github.com/seantempesta/cljs-react-navigation"
   :license {:name "MIT"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cljs-react-navigation "0.1.5-SNAPSHOT"
+(defproject cljs-react-navigation "0.1.5-SNAPSHOT_1"
   :description "CLJS Wrappers for react-navigation"
   :url "https://github.com/seantempesta/cljs-react-navigation"
   :license {:name "MIT"

--- a/src/cljs_react_navigation/base.cljs
+++ b/src/cljs_react_navigation/base.cljs
@@ -22,7 +22,7 @@
 ;; Navigators
 (defonce createNavigator (gobj/get ReactNavigation #js ["createNavigator"]))
 (defonce StackNavigator (gobj/get ReactNavigation #js ["createStackNavigator"]))
-(defonce TabNavigator (gobj/get ReactNavigation #js ["createTabNavigator"]))
+#_(defonce TabNavigator (gobj/get ReactNavigation #js ["createTabNavigator"]))
 (defonce BottonTabNavigator (gobj/get ReactNavigation #js ["createBottomTabNavigator"]))
 (defonce TopTabNavigator (gobj/get ReactNavigation #js ["createMaterialTopTabNavigator"]))
 (defonce DrawerNavigator (gobj/get ReactNavigation #js ["createDrawerNavigator"]))
@@ -36,7 +36,7 @@
 (defonce Transitioner (gobj/get ReactNavigation #js ["Transitioner"]))
 (defonce CardStack (gobj/get ReactNavigation #js ["CardStack"]))
 (defonce DrawerView (gobj/get ReactNavigation #js ["DrawerView"]))
-(defonce TabView (gobj/get ReactNavigation #js ["TabView"]))
+#_(defonce TabView (gobj/get ReactNavigation #js ["TabView"]))
 
 (assert (and React ReactNavigation) "React and React Navigation must be installed.  Maybe NPM install them and restart the packager?")
 
@@ -314,12 +314,23 @@
       (StackNavigator (clj->js routeConfigs-conformed) (clj->js StackNavigatorConfig-conformed))
       (StackNavigator (clj->js routeConfigs-conformed)))))
 
-(defn tab-navigator [routeConfigs navigationOptions]
+#_(defn tab-navigator [routeConfigs navigationOptions]
   (let [routeConfigs-conformed (s/conform :react-navigation/RouteConfigs routeConfigs)
         navigationOptions-conformed (s/conform :react-navigation/navigationOptions navigationOptions)]
     (assert (not= routeConfigs-conformed :cljs.spec.alpha/invalid))
     (assert (not= navigationOptions-conformed :cljs.spec.alpha/invalid))
     (TabNavigator (clj->js routeConfigs-conformed) (clj->js navigationOptions-conformed))))
+
+
+(defn botton-tab-navigator [routeConfigs navigationOptions]
+  ;;;;;;;;;IMHERE
+  (let [routeConfigs-conformed (s/conform :react-navigation/RouteConfigs routeConfigs)
+        navigationOptions-conformed (s/conform :react-navigation/navigationOptions navigationOptions)]
+    (assert (not= routeConfigs-conformed :cljs.spec.alpha/invalid))
+    (assert (not= navigationOptions-conformed :cljs.spec.alpha/invalid))
+    (BottonTabNavigator (clj->js routeConfigs-conformed) (clj->js navigationOptions-conformed))))
+
+
 
 (defn drawer-navigator [routeConfigs drawerNavigatorConfig]
   (let [routeConfigs-conformed (s/conform :react-navigation/RouteConfigs routeConfigs)

--- a/src/cljs_react_navigation/base.cljs
+++ b/src/cljs_react_navigation/base.cljs
@@ -11,7 +11,6 @@
 ;; Core
 (defonce createNavigationContainer (gobj/get ReactNavigation #js ["createNavigationContainer"]))
 (defonce StateUtils (gobj/get ReactNavigation #js ["StateUtils"]))
-(defonce addNavigationHelpers (gobj/get ReactNavigation #js ["addNavigationHelpers"]))
 (defonce NavigationActions (gobj/get ReactNavigation #js ["NavigationActions"]))
 (defonce NavigationActionsMap {"Navigation/INIT"       (gobj/get NavigationActions #js ["init"])
                                "Navigation/URI"        (gobj/get NavigationActions #js ["uri"])

--- a/src/cljs_react_navigation/base.cljs
+++ b/src/cljs_react_navigation/base.cljs
@@ -21,10 +21,12 @@
 
 ;; Navigators
 (defonce createNavigator (gobj/get ReactNavigation #js ["createNavigator"]))
-(defonce StackNavigator (gobj/get ReactNavigation #js ["StackNavigator"]))
-(defonce TabNavigator (gobj/get ReactNavigation #js ["TabNavigator"]))
-(defonce DrawerNavigator (gobj/get ReactNavigation #js ["DrawerNavigator"]))
-(defonce SwitchNavigator (gobj/get ReactNavigation #js ["SwitchNavigator"]))
+(defonce StackNavigator (gobj/get ReactNavigation #js ["createStackNavigator"]))
+(defonce TabNavigator (gobj/get ReactNavigation #js ["createTabNavigator"]))
+(defonce BottonTabNavigator (gobj/get ReactNavigation #js ["createBottomTabNavigator"]))
+(defonce TopTabNavigator (gobj/get ReactNavigation #js ["createMaterialTopTabNavigator"]))
+(defonce DrawerNavigator (gobj/get ReactNavigation #js ["createDrawerNavigator"]))
+(defonce SwitchNavigator (gobj/get ReactNavigation #js ["createSwitchNavigator"]))
 
 ;; Routers
 (defonce StackRouter (gobj/get ReactNavigation #js ["StackRouter"]))

--- a/src/cljs_react_navigation/re_frame.cljs
+++ b/src/cljs_react_navigation/re_frame.cljs
@@ -79,7 +79,7 @@
       (let [routing-state (or @routing-sub
                               (init-state root-router init-route-name))]
         [:> root-router {:navigation
-                         (addNavigationHelpers
+                         (base/addNavigationHelpers
                           (clj->js {:state    routing-state
                                     :addListener add-listener
                                     :dispatch (fn [action]

--- a/src/cljs_react_navigation/re_frame.cljs
+++ b/src/cljs_react_navigation/re_frame.cljs
@@ -55,7 +55,8 @@
 (def tab-screen reagent/tab-screen)
 (def drawer-component reagent/drawer-component)
 (def stack-navigator reagent/stack-navigator)
-(def tab-navigator reagent/tab-navigator)
+#_(def tab-navigator reagent/tab-navigator)
+(def botton-tab-navigator reagent/botton-tab-navigator)
 (def drawer-navigator reagent/drawer-navigator)
 (def switch-navigator reagent/switch-navigator)
 

--- a/src/cljs_react_navigation/re_frame.cljs
+++ b/src/cljs_react_navigation/re_frame.cljs
@@ -79,9 +79,8 @@
       (let [routing-state (or @routing-sub
                               (init-state root-router init-route-name))]
         [:> root-router {:navigation
-                         (base/addNavigationHelpers
-                          (clj->js {:state    routing-state
-                                    :addListener add-listener
-                                    :dispatch (fn [action]
-                                                (let [next-state (getStateForAction action routing-state)]
-                                                  (dispatch [::swap-routing-state next-state])))}))}]))))
+                         (clj->js {:state    routing-state
+                                   :addListener add-listener
+                                   :dispatch (fn [action]
+                                               (let [next-state (getStateForAction action routing-state)]
+                                                 (dispatch [::swap-routing-state next-state])))})}]))))

--- a/src/cljs_react_navigation/reagent.cljs
+++ b/src/cljs_react_navigation/reagent.cljs
@@ -73,6 +73,8 @@
 (def tab-screen base/tab-screen)
 (def drawer-component base/drawer-component)
 (def stack-navigator base/stack-navigator)
-(def tab-navigator base/tab-navigator)
+#_(def tab-navigator base/tab-navigator)
+(def botton-tab-navigator base/botton-tab-navigator)
+
 (def drawer-navigator base/drawer-navigator)
 (def switch-navigator base/switch-navigator)


### PR DESCRIPTION
I was getting this warning `WARNING: Use of undeclared Var cljs-react-navigation.re-frame/addNavigationHelpers at line 82 target/expo/cljs_react_navigation/re_frame.cljs`. This fixes that. 

Something was probably broken, functionality-wise, but I'm still figuring out this library so I don't really know what.